### PR TITLE
Fix RenderBox was not laid out error

### DIFF
--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -156,7 +156,8 @@ class _AlphabetListState extends State<AlphabetList> {
     try {
       final customScrollViewRenderBox =
           _customScrollKey.currentContext?.findRenderObject() as RenderBox?;
-      if (customScrollViewRenderBox != null) {
+      if (customScrollViewRenderBox != null &&
+          customScrollViewRenderBox.hasSize) {
         widget.symbolChangeNotifierList.value = _getFirstVisibleItemGroupSymbol(
           customScrollViewRenderBox,
           widget.items,


### PR DESCRIPTION
Check if RenderBox has a size before attempting hitTest in order to avoid RenderBox was not laid out errors. This can occur when AlphabetListView is on a page in the stack that is not visible.